### PR TITLE
feat: emptyDlq method and mode to receiver added

### DIFF
--- a/lib/clientFactories/queue.js
+++ b/lib/clientFactories/queue.js
@@ -1,4 +1,5 @@
 const debug = require('debug')('systemic-azure-bus:factory:queue');
+const { ReceiveMode } = require('@azure/service-bus');
 
 module.exports = connection => {
 	const registeredClients = [];
@@ -11,11 +12,11 @@ module.exports = connection => {
 		return client.createSender();
 	};
 
-	const createReceiver = queue => {
+	const createReceiver = (queue, mode = ReceiveMode.peekLock) => {
 		debug(`Preparing connection to receive messages from queue ${queue}...`);
 		const client = connection.createQueueClient(queue);
 		registeredClients.push(client);
-		const receiver = client.createReceiver();
+		const receiver = client.createReceiver(mode);
 		registeredReceivers.push(receiver);
 		return receiver;
 	};

--- a/test/helper.js
+++ b/test/helper.js
@@ -7,6 +7,12 @@ const busApi = initBus();
 const enoughTime = 500;
 const schedule = fn => setTimeout(fn, enoughTime);
 const createPayload = () => ({ foo: Date.now() });
+const attack = async (amount, publishFire) => {
+	await publishFire(createPayload());
+	--amount; // eslint-disable-line no-param-reassign
+	amount && attack(amount, publishFire); // eslint-disable-line no-unused-expressions
+};
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 let bus;
 
@@ -60,6 +66,7 @@ const start = async ({ config }) => {
 		purgeDlqBySubcriptionId,
 		purgeBySubcriptionId,
 		processDlq: bus.processDlq,
+		emptyDlq: bus.emptyDlq,
 		health: bus.health,
 	};
 };
@@ -72,5 +79,7 @@ const stop = async () => {
 module.exports = {
 	createPayload,
 	schedule,
+	attack,
+	sleep,
 	bus: { start, stop },
 };

--- a/test/topics/active.test.js
+++ b/test/topics/active.test.js
@@ -1,6 +1,6 @@
 require('dotenv').config();
 const expect = require('expect.js');
-const { bus, createPayload, schedule } = require('../helper');
+const { bus, schedule, attack } = require('../helper');
 
 const stressTopic = 'stress.test';
 
@@ -46,12 +46,6 @@ describe('Topics - Systemic Azure Bus API', () => {
 	it('Active peek - should contain three message', () => new Promise(async resolve => {
 		const BULLETS = 3;
 		const publishFire = busApi.publish('fire');
-		const attack = async amount => {
-			const shots = Array.from(Array(amount).keys());
-			for (shot in shots) { // eslint-disable-line guard-for-in,no-restricted-syntax
-				await publishFire(createPayload()); // eslint-disable-line no-await-in-loop
-			}
-		};
 
 		const peek = async () => {
 			const peekedMessages = await busApi.peek('assess', 3);
@@ -60,7 +54,7 @@ describe('Topics - Systemic Azure Bus API', () => {
 			resolve();
 		};
 
-		await attack(BULLETS);
+		await attack(BULLETS, publishFire);
 		schedule(peek);
 	}));
 });

--- a/test/topics/dlq.test.js
+++ b/test/topics/dlq.test.js
@@ -1,6 +1,6 @@
 require('dotenv').config();
 const expect = require('expect.js');
-const { bus, createPayload, schedule } = require('../helper');
+const { bus, schedule, attack, sleep } = require('../helper'); // eslint-disable-line object-curly-newline
 
 const stressTopic = 'stress.test';
 
@@ -44,14 +44,8 @@ describe('Topics - Systemic Azure Bus API', () => {
 	});
 
 	it('DLQ peek - should contain one message', () => new Promise(async resolve => {
-		const BULLETS = 1;
+		const BULLETS = 2;
 		const publishFire = busApi.publish('fire');
-		const attack = async amount => {
-			const shots = Array.from(Array(amount).keys());
-			for (shot in shots) { // eslint-disable-line guard-for-in,no-restricted-syntax
-				await publishFire(createPayload()); // eslint-disable-line no-await-in-loop
-			}
-		};
 
 		const peekDlq = async () => {
 			const firstMessage = await busApi.peekDlq('assess');
@@ -69,19 +63,35 @@ describe('Topics - Systemic Azure Bus API', () => {
 		};
 
 		busApi.safeSubscribe('assess', handler);
-		await attack(BULLETS);
+		await attack(BULLETS, publishFire);
 		schedule(peekDlq);
 	}));
+
+	it('DLQ empty - should empty DLQ after publish a bunch of messages and send them to DLQ', async () => {
+		const BULLETS = 20;
+		const publishFire = busApi.publish('fire');
+
+		const handler = async () => {
+			const criticalError = new Error('Throwing an error to force going to DLQ');
+			criticalError.strategy = 'deadLetter';
+			throw criticalError;
+		};
+
+		busApi.safeSubscribe('assess', handler);
+		await attack(BULLETS, publishFire);
+		await sleep(4000);
+		const messagesInDlq = await busApi.peekDlq('assess', 25);
+		expect(messagesInDlq.length).to.be(BULLETS);
+
+		await busApi.emptyDlq('assess');
+		const messagesInDlqAfterEmptying = await busApi.peekDlq('assess', BULLETS);
+
+		expect(messagesInDlqAfterEmptying.length).to.be(0);
+	});
 
 	it.skip('publishes lots of messages, sends them to DLQ and receives them all in DLQ', () => new Promise(async resolve => {
 		const BULLETS = 10;
 		const publishFire = busApi.publish('fire');
-		const attack = async amount => {
-			const shots = Array.from(Array(amount).keys());
-			for (shot in shots) { // eslint-disable-line guard-for-in,no-restricted-syntax
-				await publishFire(createPayload()); // eslint-disable-line no-await-in-loop
-			}
-		};
 
 		const purgeDlqForSubscription = async () => {
 			let receivedMessagesInDLQ = 0;
@@ -108,7 +118,7 @@ describe('Topics - Systemic Azure Bus API', () => {
 		};
 
 		busApi.safeSubscribe('assess', handler);
-		await attack(BULLETS);
+		await attack(BULLETS, publishFire);
 		schedule(purgeDlqForSubscription);
 	}));
 });

--- a/test/topics/e2e.test.js
+++ b/test/topics/e2e.test.js
@@ -1,6 +1,6 @@
 require('dotenv').config();
 const expect = require('expect.js');
-const { bus, createPayload, schedule } = require('../helper');
+const { bus, createPayload, schedule, attack } = require('../helper'); // eslint-disable-line object-curly-newline
 
 const stressTopic = 'stress.test';
 
@@ -73,12 +73,6 @@ describe('Topics - Systemic Azure Bus API', () => {
 	it('publishes lots of messages with no explicit messageId and receives them all', () => new Promise(async resolve => {
 		const BULLETS = 20;
 		const publishFire = busApi.publish('fire');
-		const attack = async amount => {
-			const shots = Array.from(Array(amount).keys());
-			for (shot in shots) { // eslint-disable-line guard-for-in,no-restricted-syntax
-				await publishFire(createPayload()); // eslint-disable-line no-await-in-loop
-			}
-		};
 
 		let received = 0;
 		const handler = async msg => {
@@ -92,7 +86,7 @@ describe('Topics - Systemic Azure Bus API', () => {
 		};
 
 		busApi.safeSubscribe('assess', handler);
-		await attack(BULLETS);
+		await attack(BULLETS, publishFire);
 	}));
 
 	it('publish a message encoded with zlib and decodes it properly', () => new Promise(async resolve => {


### PR DESCRIPTION
In this PR are added the following methods or changes:
- [added] `emptyDlq`  ==>  implemented to make the dlq emptying faster. One test for it is also added.
- [modified] `createReceiver`  ==>  added the `mode` param in order to create a queue that remove directly all the messages (for the dlq).
- [modified] `attack`  ==>  just changed a bit and place it in `helper.js` from tests.