### PR TITLE
chore: handler subscription filtering

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ module.exports = () => {
 						await handler({
 							body: getBodyDecoded(
 								brokeredMessage.body,
-								brokeredMessage.applicationProperties.contentEncoding,
+								applicationProperties.contentEncoding,
 							),
 							applicationProperties,
 							properties: getProperties(brokeredMessage),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systemic-azure-bus",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A systemic component for azure bus",
   "main": "index.js",
   "scripts": {

--- a/test/topics/dlq.test.js
+++ b/test/topics/dlq.test.js
@@ -89,11 +89,7 @@ describe('Topics - Systemic Azure Bus API - DLQ', () => {
 
 		expect(messagesInDlq.length).to.be(BULLETS);
 
-		await sleep(8000); // needed for correct peek
-
 		await busApi.emptyDlq('assess');
-
-		await sleep(8000); // needed for correct peek
 
 		const messagesInDlqAfterEmptying = await busApi.peekDlq('assess', BULLETS);
 


### PR DESCRIPTION
The subscription handler is only going to run if the `subscriptionName` property does not exists.
Or if it exists and is the current subscription from all the different ones that the topic can contain.
But the message confirmation operation will always be done, even if the handler is not executed because of the comment above.