### PR TITLE
fix: subscription handler filtering using wrong property

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,11 +67,11 @@ module.exports = () => {
 					debug(`Enqueued items increase | ${enqueuedItems} items`);
 					debug(`Handling message on topic ${topic}`);
 					const { applicationProperties } = brokeredMessage;
-					const { subscriptionName } = applicationProperties;
+					const { subscriptionName: messageSubscription } = applicationProperties;
 
-					if (!subscriptionName || subscriptionId === subscriptionName) {
+					if (!messageSubscription || subscription === messageSubscription) {
 						/**
-						 * The handler is only going to run if the "subscriptionName" property
+						 * The handler is only going to run if the "messageSubscription" property
 						 * does not exists. Or if it exists and is the current subscription from all
 						 * the different ones that the topic can contain.
 						 * But the message confirmation operation will always be done, even if the handler

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systemic-azure-bus",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "A systemic component for azure bus",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The previous PR was using the wrong handler `applicationProperties` properties.
The previous added tests were wrong because there was some `async` checks not validated for knowing if the messages is already handled or not. That's not possible to introduce any BUG like it is right now.

Old PR for more context: (https://github.com/guidesmiths/systemic-azure-bus/pull/50)