### PR TITLE
made message fields available & typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,53 @@
+import { Component } from 'systemic'
+import { ServiceBusMessage, ServiceBusReceivedMessage } from '@azure/service-bus'
+
+/**
+ * Configuration for the Systemic Azure Service Bus Component
+ */
+export type Config<TPublications extends Record<string, unknown>, TSubstriptions extends Record<string, unknown>> = {
+  connection: {
+    connectionString: string
+  }
+  publications?: Record<keyof TPublications, { topic: string; contentType: string }>
+  subscriptions?: Record<keyof TSubstriptions, { topic: string; subscription: string }>
+}
+
+export type Bus<TPublications, TSubstriptions> = PublicationBus<TPublications> & SubscriptionBus<TSubstriptions>
+
+export type PublicationBus<TPublications> = {
+  /**
+   * publishes a message on the bus
+   */
+  publish: <TTopic extends keyof TPublications>(
+    publicationName: TTopic,
+  ) => (message: TPublications[TTopic], options?: Omit<ServiceBusMessage, 'body'> & { label?: string, contentEncoding?: 'zlib' | 'default' }) => Promise<void>
+}
+
+export type SubscriptionBus<TSubstriptions> = {
+  /**
+   * subscribe to events on the bus
+   * @returns A function that can be used to subribe to a topic on the bus, by providing topic name and a handler that
+   * is invoked when a message is received.
+   */
+  subscribe: (
+    onProcessError: (error: Error) => void,
+  ) => <TTopic extends keyof TSubstriptions>(
+      subscriptionName: TTopic,
+      handler: (message: {
+        body: TSubstriptions[TTopic]
+        applicationProperties: ServiceBusReceivedMessage['applicationProperties']
+        properties: Omit<ServiceBusReceivedMessage, 'body' | 'applicationProperties'>
+      }) => Promise<void> | void,
+    ) => void
+}
+
+/**
+ * Initializes a Systemic Azure Service Bus Component.
+ * @param {Config} config Configuration for the component
+ */
+declare function initBus<
+  TPublications extends Record<string, unknown> = Record<string, unknown>,
+  TSubstriptions extends Record<string, unknown> = Record<string, unknown>,
+  >(): Component<Bus<TPublications, TSubstriptions>, { config: Config<TPublications, TSubstriptions> }>
+
+export default initBus

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = () => {
 	let topicClientFactory;
 	let queueClientFactory;
 	let enqueuedItems = 0;
-	const sendersByPublication = [];
+	const sendersByPublication = {};
 
 	const start = async ({
 		config: {
@@ -37,18 +37,12 @@ module.exports = () => {
 		const publish = publicationId => {
 			const { topic } = publications[publicationId] || {};
 			if (!topic) throw new Error(`Topic for publication ${publicationId} non found!`);
-			let { sender } = sendersByPublication.find(senderByPub => senderByPub.publicationId === publicationId) || {};
+			let sender = sendersByPublication[publicationId];
 			if (!sender) {
 				sender = topicClientFactory.createSender(topic);
-				sendersByPublication.push({ publicationId, sender });
+				sendersByPublication[publicationId] = sender;
 			}
 			return topicApi.publish(sender);
-		};
-		const getProperties = message => {
-			const properties = {
-				messageId: message.messageId,
-			};
-			return properties;
 		};
 
 		const subscribe = onError => (subscriptionId, handler) => {
@@ -66,7 +60,7 @@ module.exports = () => {
 					enqueuedItems++;
 					debug(`Enqueued items increase | ${enqueuedItems} items`);
 					debug(`Handling message on topic ${topic}`);
-					const { applicationProperties } = brokeredMessage;
+					const { body, applicationProperties, ...properties } = brokeredMessage;
 					const { subscriptionName: messageSubscription } = applicationProperties;
 
 					if (!messageSubscription || subscription === messageSubscription) {
@@ -79,11 +73,11 @@ module.exports = () => {
 						 */
 						await handler({
 							body: getBodyDecoded(
-								brokeredMessage.body,
+								body,
 								applicationProperties.contentEncoding,
 							),
 							applicationProperties,
-							properties: getProperties(brokeredMessage),
+							properties,
 						});
 					}
 					await receiver.completeMessage(brokeredMessage);

--- a/lib/clientFactories/topics.js
+++ b/lib/clientFactories/topics.js
@@ -1,8 +1,8 @@
 const debug = require('debug')('systemic-azure-bus:factory:topic');
 
 module.exports = sbClient => {
-	const registeredReceivers = [];
-	const registeredSenders = [];
+	let registeredReceivers = [];
+	let registeredSenders = [];
 
 	const createSender = topic => {
 		debug(`Preparing connection to publish on topic ${topic}...`);
@@ -28,10 +28,12 @@ module.exports = sbClient => {
 		for (const receiver of registeredReceivers) { // eslint-disable-line no-restricted-syntax
 			await receiver.close(); // eslint-disable-line no-await-in-loop
 		}
+		registeredReceivers = [];
 		debug('Stopping registered senders...');
 		for (const sender of registeredSenders) { // eslint-disable-line no-restricted-syntax
 			await sender.close(); // eslint-disable-line no-await-in-loop
 		}
+		registeredSenders = [];
 	};
 
 	return {

--- a/lib/operations/topics/publish.js
+++ b/lib/operations/topics/publish.js
@@ -10,17 +10,17 @@ const encodingStrategies = {
 
 const getBodyEncoded = (body, contentEncoding) => (encodingStrategies[contentEncoding] || encodingStrategies.default)(body);
 
-module.exports = sender => async (body, { messageId, label = '', contentType, contentEncoding, applicationProperties, scheduledEnqueueTimeUtc } = {}) => { // eslint-disable-line object-curly-newline
+module.exports = sender => async (body, options = {}) => { // eslint-disable-line object-curly-newline
+	const { label = '', contentEncoding, applicationProperties, scheduledEnqueueTimeUtc, ...messageFields } = options;
 	const message = {
-		body: getBodyEncoded(body, contentEncoding),
-		messageId,
 		label,
-		contentType,
 		applicationProperties: {
 			contentEncoding,
-			...applicationProperties,
 			attemptCount: 0,
+			...applicationProperties,
 		},
+		...messageFields,
+		body: getBodyEncoded(body, contentEncoding),
 	};
 
 	let isMessageSent = false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -291,6 +291,12 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "async": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
+      "dev": true
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -394,6 +400,12 @@
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
+    },
+    "chance": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/chance/-/chance-1.1.8.tgz",
+      "integrity": "sha512-v7fi5Hj2VbR6dJEGRWLmJBA83LJMS47pkAbmROFxHWd9qmE1esHRZW8Clf1Fhzr3rjxnNZVCjOEv/ivFxeIMtg==",
+      "dev": true
     },
     "chardet": {
       "version": "0.7.0",
@@ -2508,6 +2520,19 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
     },
+    "systemic": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/systemic/-/systemic-3.3.10.tgz",
+      "integrity": "sha512-EJ96/Adm9w3TE7DXRSMru4yxLnyNsVh2Y7nRgZnZ6bNmHIo4mlnR1XwiANBKiaUYzgweo80u2exiO5aW3xroIQ==",
+      "dev": true,
+      "requires": {
+        "async": "^3.2.0",
+        "chance": "^1.1.7",
+        "debug": "^4.3.1",
+        "require-all": "^3.0.0",
+        "toposort-class": "^1.0.1"
+      }
+    },
     "table": {
       "version": "5.4.6",
       "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
@@ -2568,6 +2593,12 @@
       "requires": {
         "os-tmpdir": "~1.0.2"
       }
+    },
+    "toposort-class": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
+      "integrity": "sha1-f/0feMi+KMO6Rc1OGj9e4ZO9mYg=",
+      "dev": true
     },
     "tough-cookie": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint-plugin-mocha": "^5.3.0",
     "expect.js": "^0.3.1",
     "husky": "^1.3.1",
-    "mocha": "^6.1.4"
+    "mocha": "^6.1.4",
+    "systemic": "^3.3.10"
   }
 }

--- a/test/topics/e2e.test.js
+++ b/test/topics/e2e.test.js
@@ -61,6 +61,7 @@ describe('Topics - Systemic Azure Bus API', () => {
 	it('publish a message with explicit messageId and check structure on receiving', () => new Promise(async resolve => {
 		const payload = createPayload();
 		const messageId = '1234567890';
+		const correlationId = 'abc123';
 		const publish = busApi.publish('fire');
 
 		const handler = async msg => {
@@ -70,11 +71,12 @@ describe('Topics - Systemic Azure Bus API', () => {
 			expect(applicationProperties).to.be.an('object');
 			expect(body).to.be.eql(payload);
 			expect(properties.messageId).to.be.eql(messageId);
+			expect(properties.correlationId).to.be.equal(correlationId);
 			resolve();
 		};
 
 		busApi.safeSubscribe('assess', handler);
-		await publish(payload, { messageId });
+		await publish(payload, { messageId, correlationId });
 	}));
 
 	it('publish a message with explicit messageId and check scheduler on receiving', () => new Promise(async resolve => {

--- a/test/unit/publish.test.js
+++ b/test/unit/publish.test.js
@@ -1,3 +1,6 @@
+const zlib = require('zlib');
+const expect = require('expect.js');
+
 const publish = require('../../lib/operations/topics/publish');
 
 const createPayload = () => ({ foo: Date.now() });
@@ -44,4 +47,22 @@ describe('Publish  message on Topic', () => {
 			resolve();
 		}
 	}));
+
+	it('Should send all message fields', async () => {
+		let received = null;
+		const sender = {
+			sendMessages: message => { received = message; },
+		};
+
+		const body = createPayload();
+		const endcodedBody = zlib.deflateSync(Buffer.from(JSON.stringify(body))).toString();
+		const options = { contentEncoding: 'zlib', applicationProperties: { bar: 'baz' }, correlationId: '123abc' };
+		const publishMessage = publish(sender);
+
+		await publishMessage(body, options);
+
+		expect(received.applicationProperties).to.eql({ contentEncoding: 'zlib', attemptCount: 0, bar: 'baz' });
+		expect(received.correlationId).to.equal(options.correlationId);
+		expect(received.body.toString()).to.equal(endcodedBody);
+	});
 });


### PR DESCRIPTION
From #64 

Implements https://github.com/guidesmiths/systemic-azure-bus/issues/63

In publish also accept all other message props in 2nd param and add those to the message
Extended handler properties input field to also inclide remaining message fields
In v3.3.10 typescript definitions were added to [Systemic](https://github.com/guidesmiths/systemic). This PR also adds definitions to the Systemic Azure bus component.