### PR TITLE
Chore/return published message reference

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,11 @@ module.exports = () => {
 			return topicApi.publish(sender);
 		};
 
+		const cancelScheduledMessages = async (publicationId, sequenceNumber) => {
+			debug(`Cancelling messages ${sequenceNumber} for topic ${publicationId}`);
+			return sendersByPublication[publicationId].cancelScheduledMessages(sequenceNumber);
+		};
+
 		const getMessageProperties = brokeredMessage => {
 			const {
 				// ServiceBusReceivedMessage
@@ -261,6 +266,7 @@ module.exports = () => {
 		return {
 			health,
 			publish,
+			cancelScheduledMessages,
 			subscribe,
 			peekDlq,
 			peek,

--- a/lib/operations/topics/publish.js
+++ b/lib/operations/topics/publish.js
@@ -24,27 +24,28 @@ module.exports = sender => async (body, options = {}) => { // eslint-disable-lin
 		body: getBodyEncoded(body, contentEncoding),
 	};
 
+	let isMessageSent = false;
 	let attempts = 0;
 	let lastError = null;
-	// Messages not being sent would not get a sequence number assigned
 	let sequenceNumber;
 
-	while (!sequenceNumber && attempts < 3) {
+	while (!isMessageSent && attempts < 3) {
 		try {
 			if (scheduledEnqueueTimeUtc) {
 				// eslint-disable-next-line no-await-in-loop
 				sequenceNumber = await sender.scheduleMessages([message], scheduledEnqueueTimeUtc);
 			} else {
 				// eslint-disable-next-line no-await-in-loop
-				sequenceNumber = await sender.sendMessages(message);
+				await sender.sendMessages(message);
 			}
+			isMessageSent = true;
 		} catch (err) {
 			lastError = err;
 			attempts++;
 		}
 	}
 
-	if (!sequenceNumber && lastError) throw lastError;
+	if (!isMessageSent && lastError) throw lastError;
 
 	return Promise.resolve(sequenceNumber);
 };

--- a/lib/operations/topics/publish.js
+++ b/lib/operations/topics/publish.js
@@ -24,25 +24,27 @@ module.exports = sender => async (body, options = {}) => { // eslint-disable-lin
 		body: getBodyEncoded(body, contentEncoding),
 	};
 
-	let isMessageSent = false;
 	let attempts = 0;
 	let lastError = null;
+	// Messages not being sent would not get a sequence number assigned
+	let sequenceNumber;
 
-	while (!isMessageSent && attempts < 3) {
+	while (!sequenceNumber && attempts < 3) {
 		try {
 			if (scheduledEnqueueTimeUtc) {
 				// eslint-disable-next-line no-await-in-loop
-				await sender.scheduleMessages([message], scheduledEnqueueTimeUtc);
+				sequenceNumber = await sender.scheduleMessages([message], scheduledEnqueueTimeUtc);
 			} else {
 				// eslint-disable-next-line no-await-in-loop
-				await sender.sendMessages(message);
+				sequenceNumber = await sender.sendMessages(message);
 			}
-			isMessageSent = true;
 		} catch (err) {
 			lastError = err;
 			attempts++;
 		}
 	}
 
-	if (!isMessageSent && lastError) throw lastError;
+	if (!sequenceNumber && lastError) throw lastError;
+
+	return Promise.resolve(sequenceNumber);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "systemic-azure-bus",
-  "version": "3.3.3",
+  "version": "3.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "systemic-azure-bus",
-      "version": "3.3.3",
+      "version": "3.4.1",
       "license": "ISC",
       "dependencies": {
         "@azure/service-bus": "^7.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systemic-azure-bus",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "A systemic component for azure bus",
   "main": "index.js",
   "scripts": {

--- a/test/helper.js
+++ b/test/helper.js
@@ -61,6 +61,7 @@ const start = async ({ config }) => {
 	return {
 		safeSubscribe: bus.subscribe(console.error), // eslint-disable-line no-console
 		publish: bus.publish,
+		cancelScheduledMessages: bus.cancelScheduledMessages,
 		peekDlq: bus.peekDlq,
 		peek: bus.peek,
 		purgeDlqBySubcriptionId,

--- a/test/topics/e2e.test.js
+++ b/test/topics/e2e.test.js
@@ -79,6 +79,52 @@ describe('Topics - Systemic Azure Bus API', () => {
 		await publish(payload, { messageId, correlationId });
 	}));
 
+	it('publish a message with explicit correlationId and cancel it before receiving', () => new Promise(async (resolve, reject) => {
+		const payload = createPayload();
+		const publish = busApi.publish('fire');
+
+		let isConsumedMessage;
+		const now = Date.now();
+		const toConsumeMessageId = `${now}-to-consume-123`;
+		const toConsumeCorrelationId = `${now}-to-consume-456`;
+
+		const toCancelMessageId = `${now}-to-cancel-123`;
+		const toCancelCorrelationId = `${now}-to-cancel-456`;
+
+		busApi.safeSubscribe('assess', async msg => {
+			if (msg.properties.messageId === toConsumeMessageId) {
+				isConsumedMessage = toConsumeMessageId;
+			}
+		});
+
+		busApi.safeSubscribe('assess', async msg => {
+			if (msg.properties.messageId === toCancelMessageId) {
+				reject(new Error(`Message not cancelled! -> ${msg.properties.correlationId}`));
+			}
+		});
+
+		// That one needs to get consumed before for making sure sequence numbers are not decreased
+		const toConsumeScheduledEnqueueTimeUtc = new Date(Date.now() + 2000);
+		await publish(payload, {
+			messageId: toConsumeMessageId,
+			correlationId: toConsumeCorrelationId,
+			scheduledEnqueueTimeUtc: toConsumeScheduledEnqueueTimeUtc,
+		});
+
+		const toCancelScheduledEnqueueTimeUtc = new Date(Date.now() + 4000);
+		const toCancelSequenceNumber = await publish(payload, {
+			messageId: toCancelMessageId,
+			correlationId: toCancelCorrelationId,
+			scheduledEnqueueTimeUtc: toCancelScheduledEnqueueTimeUtc,
+		});
+
+		await busApi.cancelScheduledMessages('fire', toCancelSequenceNumber);
+		await sleep(6000);
+
+		expect(isConsumedMessage).to.be.eql(toConsumeMessageId);
+		resolve();
+	}));
+
 	it('publish a message with explicit messageId and check scheduler on receiving', () => new Promise(async resolve => {
 		const payload = createPayload();
 		const messageId = '1234567890';


### PR DESCRIPTION
### Type:
* ~cicd: helm, docker & cicd adjustments.~
* feature: new capabilities.
* ~fix: bug, hotfix, etc.~
* ~refactor: enhacements.~
* other: docs, tests.

### What's the focus of this PR:
Since the possibility to publish scheduled messages is available. We also need now to be able to cancel scheduled messages that has not been consumed yet.

### Task list:

:cyclone: **Components**
- [x] `cancelScheduledMessages` new method available

:heavy_check_mark: **Test**
- [x] Canceled messages should not be consumed.